### PR TITLE
Use br prefix instead of rb

### DIFF
--- a/modulegraph/util.py
+++ b/modulegraph/util.py
@@ -105,7 +105,7 @@ def imp_walk(name):
     raise ImportError("No module named %s" % (name,))
 
 
-cookie_re = re.compile(rb"coding[:=]\s*([-\w.]+)")
+cookie_re = re.compile(br"coding[:=]\s*([-\w.]+)")
 if sys.version_info[0] == 2:
     default_encoding = "ascii"
 else:


### PR DESCRIPTION
These behave identically except that rb was not allowed until Python 3.3.